### PR TITLE
Valve tweak.

### DIFF
--- a/lib/valve.js
+++ b/lib/valve.js
@@ -58,7 +58,7 @@ State.prototype.destroy = function destroy() {
     source.removeListener(consts.END,   this.onEnd);
     source.removeListener(consts.ERROR, this.onError);
 
-    this.paused  = true;
+    this.paused  = false;
     this.buffer  = undefined;
     this.emitter = undefined;
     this.ended   = true;


### PR DESCRIPTION
This makes it possible for callbacks to no-op gracefully after a valve
gets destroyed.
