### PR TITLE
Add construction-time checks for already-ended streams.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ not pass through the flow-control methods `pause()` and `resume()`,
 nor do they respond to `destroy()` by trying to destroy the underlying
 stream(s).
 
+In addition, these layering classes check upon construction that their
+upstream sources are in fact streams that have not yet been ended
+(that is, that they are still capable of emitting events). If a stream
+source argument fails this check, then the constructor call will throw
+an exception indicating that fact. The check is somewhat conservative
+and meant to be accepting of stream-like event emitters in addition to
+checking bona fide `Stream` instances. Details: If a given source is
+a `Stream` per se, then the value of `source.readable` is taken at face
+value. Otherwise, a source is considered to be ended if and only if
+it (or a prototype in its chain) defines a `readable` property and
+that property is falsey.
+
+
 ### Blip
 
 The `Blip` class exists to emit a single `data` event using the standard

--- a/lib/cat.js
+++ b/lib/cat.js
@@ -16,6 +16,7 @@ var util = require("util");
 
 var consts = require("./consts");
 var sealer = require("./sealer");
+var sourcesanity = require("./sourcesanity");
 
 var Blip = require("./blip").Blip;
 var Valve = require("./valve").Valve;
@@ -48,8 +49,12 @@ function State(emitter, streams, paused) {
     for (var i = 0; i < streams.length; i++) {
         var one = streams[i];
 
-        if (!(one && (typeof one.on === "function"))) {
-            throw new Error("Invalid stream: index " + i);
+        try {
+            sourcesanity.validate(one);
+        } catch (ex) {
+            // Clarify with the index.
+            var message = ex.message.replace(/\.$/, ": index " + i);
+            throw new Error(message);
         }
 
         // Always make a valve around the given streams, so that we

--- a/lib/sink.js
+++ b/lib/sink.js
@@ -18,6 +18,7 @@ var util = require("util");
 var consts = require("./consts");
 var Codec = require("./codec").Codec;
 var sealer = require("./sealer");
+var sourcesanity = require("./sourcesanity");
 
 
 /*
@@ -40,11 +41,7 @@ var NO_ERROR = [ "no-error" ];
  * Construct a Sink state object.
  */
 function State(emitter, source) {
-    assert.ok(source !== undefined, "Missing source.");
-
-    if (typeof source.on !== "function") {
-        throw new Error("Source not an EventEmitter.");
-    }
+    sourcesanity.validate(source);
 
     /** "parent" emitter */
     this.emitter = emitter;

--- a/lib/sourcesanity.js
+++ b/lib/sourcesanity.js
@@ -14,15 +14,6 @@
 var assert = require("assert");
 var stream = require("stream");
 
-var Blip = require("./blip").Blip;
-
-/*
- * Module variables
- */
-
-/** Special flag used to indicate that a source is a replacement */
-var REPLACEMENT_FLAG = [ "replacement-flag" ];
-
 
 /*
  * Exported bindings

--- a/lib/sourcesanity.js
+++ b/lib/sourcesanity.js
@@ -1,0 +1,76 @@
+// Copyright 2012 The Obvious Corporation.
+
+/*
+ * Validation and sanitization of upstream sources.
+ */
+
+
+/*
+ * Modules used
+ */
+
+"use strict";
+
+var assert = require("assert");
+var stream = require("stream");
+
+var Blip = require("./blip").Blip;
+
+/*
+ * Module variables
+ */
+
+/** Special flag used to indicate that a source is a replacement */
+var REPLACEMENT_FLAG = [ "replacement-flag" ];
+
+
+/*
+ * Exported bindings
+ */
+
+/**
+ * Checks to see if a
+ * readable-stream-like event emitter has ended, in a somewhat
+ * safer / more conservative way than just looking at `source.readable`.
+ *
+ * In particular, this does used `source.readable` if `source` is
+ * actually an instance of `stream.Stream`. However, if it is not,
+ * then the `readable` property is only checked if it is actually
+ * defined on the source (including on prototypes).
+ */
+function isEnded(source) {
+    return ((source instanceof stream.Stream) || ("readable" in source)) &&
+        !source.readable;
+}
+
+/**
+ * Validates the given `source`, which must be a stream-like event
+ * emitter.
+ *
+ * This checks to make sure that the source is defined and
+ * has at least the trappings of being an emitter. If not,
+ * this throws an error.
+ *
+ * In addition, if the source either derives from `stream.Stream` or
+ * has an explicitly-defined `readable` property, then the truthiness
+ * of `readable` is used to determine if the source is already closed.
+ * (That is, if `source.readable` is falsey then the source is
+ * considered closed.) And if so, this method throws an error to
+ * indicate that fact.
+ */
+function validate(source) {
+    assert.ok((source !== undefined) && (source !== null), "Missing source.");
+
+    if (typeof source.on !== "function") {
+        throw new Error("Source not an EventEmitter.");
+    }
+
+    if (isEnded(source)) {
+        throw new Error("Source already ended.");
+    }
+}
+
+module.exports = {
+    isEnded: isEnded,
+    validate: validate
+};

--- a/lib/valve.js
+++ b/lib/valve.js
@@ -14,10 +14,11 @@
 
 var assert = require("assert");
 var stream = require("stream");
-var util   = require("util");
+var util = require("util");
 
 var consts = require("./consts");
 var sealer = require("./sealer");
+var sourcesanity = require("./sourcesanity");
 
 
 /*
@@ -28,6 +29,8 @@ var sealer = require("./sealer");
  * Construct a Valve state object.
  */
 function State(emitter, source, paused) {
+    sourcesanity.validate(source);
+
     this.emitter = emitter;
     this.source  = source;
     this.paused  = (paused === undefined) ? true : !!paused;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pipette",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "keywords":
         ["stream", "pipe", "buffer", "valve", "data", "event", "blip", "cat",
          "sink"],

--- a/test/sink.js
+++ b/test/sink.js
@@ -9,6 +9,7 @@
 var assert = require("assert");
 var events = require("events");
 
+var Blip = require("../").Blip;
 var Sink = require("../").Sink;
 
 var EventCollector = require("./eventcoll").EventCollector;
@@ -39,6 +40,15 @@ function needSource() {
         new Sink(["hello"]);
     }
     assert.throws(f2, /Source not an EventEmitter/);
+
+    // This is an already-ended Stream-per-se.
+    var bad = new Blip(); 
+    bad.resume();
+
+    function f3() {
+        new Sink(bad);
+    }
+    assert.throws(f3, /Source already ended./);
 }
 
 /**

--- a/test/valve.js
+++ b/test/valve.js
@@ -9,6 +9,7 @@
 var assert = require("assert");
 var events = require("events");
 
+var Blip = require("../").Blip;
 var Valve = require("../").Valve;
 
 var EventCollector = require("./eventcoll").EventCollector;
@@ -41,6 +42,15 @@ function needSource() {
         new Valve(["hello"]);
     }
     assert.throws(f2, /Source not an EventEmitter/);
+
+    // This is an already-ended Stream-per-se.
+    var bad = new Blip(); 
+    bad.resume();
+
+    function f3() {
+        new Valve(bad);
+    }
+    assert.throws(f3, /Source already ended./);
 }
 
 /**


### PR DESCRIPTION
Original commit message below.

This addresses @dpup's comment from PR #7.

/cc @dpup 
/cc @mikefleming 

R=mike
R=dan
###### 

This also factors out the rest of the source validation code.

I ended up implementing this to throw when the edge case in question is
detected, rather than silently papering over it, because this imposes a
more minimal burden and provides an opportunity to catch programming
errors.

If we also want to have a way to silently accept ended streams, I can
build that, but it'll be a little more involved. I _think_ the right
way to do that would be to define alternate constructor functions that
make it clear that that's what's happening. (And if so, please consider
that to be out-of-scope for this PR.)
