### PR TITLE
Always include a `close` event after `error` events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,34 @@ pipette: Pipe-like utilities for Node
 =====================================
 
 This Node module provides several utility classes that offer
-pipe and stream-related functionality.
+pipe and stream-related functionality. It particularly emphasizes
+providing a consistent event packaging and ordering for streams.
+
+
+Building and Installing
+-----------------------
+
+```shell
+npm install pipette
+```
+
+Or grab the source. As of this writing, this module has no
+dependencies, so once you have the source, there's nothing more to do
+to "build" it.
+
+
+Testing
+-------
+
+```shell
+npm test
+```
+
+Or
+
+```shell
+node ./test/test.js
+```
 
 
 Event Sequence Philosophy
@@ -65,6 +92,9 @@ value. Otherwise, a source is considered to be ended if and only if
 it (or a prototype in its chain) defines a `readable` property and
 that property is falsey.
 
+
+Class Overview
+--------------
 
 ### Blip
 
@@ -160,32 +190,6 @@ function httpRequestCallback(request, response) {
         thingThatWantsToRead.startReading(valve);
     });
 }
-```
-
-
-Building and Installing
------------------------
-
-```shell
-npm install pipette
-```
-
-Or grab the source. As of this writing, this module has no
-dependencies, so once you have the source, there's nothing more to do
-to "build" it.
-
-
-Testing
--------
-
-```shell
-npm test
-```
-
-Or
-
-```shell
-node ./test/test.js
 ```
 
 

--- a/lib/cat.js
+++ b/lib/cat.js
@@ -84,7 +84,19 @@ function State(emitter, streams, paused) {
     }
 }
 
+/**
+ * Detach any streams that are left, and make this instance well and
+ * truly closed.
+ */
 State.prototype.destroy = function destroy() {
+    var streams = this.streams;
+
+    if (streams) {
+        for (var i = 0; i < streams.length; i++) {
+            streams[i].destroy();
+        }
+    }
+
     this.emitter = undefined;
     this.streams = undefined;
     this.paused = false;
@@ -120,6 +132,12 @@ State.prototype.resume = function resume() {
  * perhaps on the paranoide side.
  */
 State.prototype.onCloseOrEnd = function onCloseEnd() {
+    if (!this.readable) {
+        // We probably got here because of a `close` event
+        // that arrived after an `error`. Nothing to do but ignore it.
+        return;
+    }
+
     var streams = this.streams;
 
     streams[0].destroy();
@@ -140,12 +158,15 @@ State.prototype.onData = function onData(data) {
 }
 
 /**
- * An error in a sub-stream causes this instance to emit an error and
- * then stop (as if ended/closed).
+ * An error in a sub-stream causes this instance to emit `error` and
+ * `close` events (in that order), and then stop.
  */
 State.prototype.onError = function onError(error) {
     this.emitter.emit(consts.ERROR, error);
-    this.readable = false;
+    this.emitter.emit(consts.CLOSE);
+
+    // Clean up and mark ourselves as closed / un-readable.
+    this.destroy();
 }
 
 

--- a/lib/sink.js
+++ b/lib/sink.js
@@ -158,10 +158,11 @@ State.prototype.emitAllEvents = function emitAllEvents() {
 
     if (error === NO_ERROR) {
         emitter.emit(consts.END);
-        emitter.emit(consts.CLOSE);
     } else {
         emitter.emit(consts.ERROR, error);
     }
+
+    emitter.emit(consts.CLOSE);
 
     this.ended = true;
 }

--- a/lib/valve.js
+++ b/lib/valve.js
@@ -36,7 +36,6 @@ function State(emitter, source, paused) {
     this.paused  = (paused === undefined) ? true : !!paused;
     this.buffer  = [];
     this.ended   = false;
-    this.closed  = false;
 
     // We `bind()` the event listener callback methods, so that they
     // get an appropriate `this` when they're called during event
@@ -59,16 +58,17 @@ function State(emitter, source, paused) {
 State.prototype.destroy = function destroy() {
     var source = this.source;
 
-    source.removeListener(consts.CLOSE, this.onClose);
-    source.removeListener(consts.DATA,  this.onData);
-    source.removeListener(consts.END,   this.onEnd);
-    source.removeListener(consts.ERROR, this.onError);
+    if (source) {
+        source.removeListener(consts.CLOSE, this.onClose);
+        source.removeListener(consts.DATA,  this.onData);
+        source.removeListener(consts.END,   this.onEnd);
+        source.removeListener(consts.ERROR, this.onError);
+    }
 
     this.paused  = false;
     this.buffer  = undefined;
     this.emitter = undefined;
     this.ended   = true;
-    this.closed  = true;
 };
 
 State.prototype.isReadable = function isReadable() {
@@ -93,13 +93,44 @@ State.prototype.resume = function resume() {
     }
 };
 
+/**
+ * If not yet ended, this emits a final informational event (either an
+ * `end` or an `error`) followed by a `close` event. Then, this marks
+ * the instance as ended. For an `end` event, the event argument is
+ * ignored. This method does nothing if the instance is already ended.
+ *
+ * Note: The `isError` argument is necessary, since it is valid to
+ * emit an `error` event with an arbitrary payload, including
+ * `undefined`.
+ */
+State.prototype.end = function end(isError, errorArg) {
+    if (this.ended) {
+        return;
+    }
+
+    // Capture the emitter in a local, becuase emitting the
+    // informational event could cause this instance to be
+    // synchronously destroyed. However, it's still appropriate to get
+    // the `close` event out.
+    var emitter = this.emitter;
+
+    if (emitter) {
+        if (isError) {
+            emitter.emit(consts.ERROR, errorArg);
+        } else {
+            emitter.emit(consts.END);
+        }
+        emitter.emit(consts.CLOSE);
+    }
+
+    this.destroy();
+}
+
 State.prototype.onClose = function onClose() {
     if (this.paused) {
         this.buffer.push({ func: this.onClose });
-    } else if (this.emitter && !this.closed) {
-        this.emitter.emit(consts.CLOSE);
-        this.ended = true;
-        this.closed = true;
+    } else {
+        this.end(false);
     }
 }
 
@@ -114,19 +145,16 @@ State.prototype.onData = function onData(data) {
 State.prototype.onEnd = function onEnd() {
     if (this.paused) {
         this.buffer.push({ func: this.onEnd });
-    } else if (this.emitter && !this.ended) {
-        this.emitter.emit(consts.END);
-        this.ended = true;
+    } else {
+        this.end(false);
     }
 }
 
 State.prototype.onError = function onError(error) {
     if (this.paused) {
         this.buffer.push({ func: this.onError, arg: error });
-    } else if (this.emitter && !this.closed) {
-        this.emitter.emit(consts.ERROR, error);
-        this.ended = true;
-        this.closed = true;
+    } else {
+        this.end(true, error);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pipette",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "keywords":
         ["stream", "pipe", "buffer", "valve", "data", "event", "blip", "cat",
          "sink"],

--- a/test/cat.js
+++ b/test/cat.js
@@ -27,6 +27,7 @@ function makeErrorBlip(error) {
 
     var valve = new pipette.Valve(emitter);
     emitter.emit("error", error);
+    emitter.emit("close");
 
     return valve;
 }
@@ -197,13 +198,14 @@ function basicErrorEventSequence() {
         coll.listenAllCommon(cat);
         cat.resume();
 
-        assert.equal(coll.events.length, errorAt + 1);
+        assert.equal(coll.events.length, errorAt + 2);
 
         for (var i = 0; i < errorAt; i++) {
             coll.assertEvent(i, cat, "data", ["" + i]);
         }
 
         coll.assertEvent(errorAt, cat, "error", [theError]);
+        coll.assertEvent(errorAt + 1, cat, "close");
     }
 }
 

--- a/test/sink.js
+++ b/test/sink.js
@@ -113,7 +113,7 @@ function readableTransition() {
             sink.resume();
         }
 
-        assert.equal(coll.events.length, (name === "error") ? 1 : 2);
+        assert.equal(coll.events.length, 2);
         assert.ok(!sink.readable);
     }
 }
@@ -136,7 +136,7 @@ function eventsAfterEnd() {
 
         coll.listenAllCommon(sink);
         emit(source, name, arg);
-        assert.equal(coll.events.length, (name === "error") ? 1 : 2);
+        assert.equal(coll.events.length, 2);
         coll.reset();
 
         if (extraData) {
@@ -172,7 +172,7 @@ function noDataEvents() {
         coll.listenAllCommon(sink);
         emit(source, endEvent, endArg);
 
-        assert.equal(coll.events.length, isError ? 1 : 2);
+        assert.equal(coll.events.length, 2);
 
         if (isError) {
             coll.assertEvent(0, sink, "error", [endArg]);
@@ -203,15 +203,16 @@ function singleDataEvent() {
         source.emit("data", theData);
         emit(source, endEvent, endArg);
 
-        assert.equal(coll.events.length, isError ? 2 : 3);
+        assert.equal(coll.events.length, 3);
         coll.assertEvent(0, sink, "data", [theData]);
 
         if (isError) {
             coll.assertEvent(1, sink, "error", [endArg]);
         } else {
             coll.assertEvent(1, sink, "end", undefined);
-            coll.assertEvent(2, sink, "close", undefined);
         }
+
+        coll.assertEvent(2, sink, "close", undefined);
     }
 }
 


### PR DESCRIPTION
This makes some coding patterns much simpler.

Note: This is an intermediate check-in. I expect to change to how the
filter classes handle `close` events that they recieve, in an upcoming
change.

/cc @mikefleming 
/cc @dpup 

R=mike
R=dan
