### PR TITLE
Remove the `paused` constructor argument for `Pipe`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,14 +269,10 @@ streams passed to it. Instead, it buffers events internally.
 Pipe
 ----
 
-### var pipe = new Pipe([paused])
+### var pipe = new Pipe()
 
 Constructs and returns a new pipe pair. The result is an object with
 mappings for `{ reader, writer }` for the two ends of the pipe.
-
-If the optional `paused` argument is specified, it indicates whether
-or not the reader side should start out in the paused state. It defaults
-to `false`.
 
 The reader and writer side each implement the standard Node stream
 protocol for readable and writable streams (respectively).

--- a/lib/pipe.js
+++ b/lib/pipe.js
@@ -214,19 +214,12 @@ Object.freeze(Writer.prototype);
  * to which event listeners may be attached. The writer similarly
  * implements the writable stream protocol and emits the expected
  * events.
- *
- * The optional `paused` argument indicates whether the reader side should
- * start out paused (defaults to `false`).
  */
-function Pipe(paused) {
+function Pipe() {
     var state = new State();
     var sealedState = sealer.seal(state);
     this.reader = state.reader = new Reader(sealedState);
     this.writer = state.writer = new Writer(sealedState);
-
-    if (paused) {
-        this.reader.pause();
-    }
 }
 
 Object.freeze(Pipe.prototype);

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -30,9 +30,6 @@ function constructor() {
     assert.ok(pipe.writer);
     assert.ok(pipe.reader instanceof stream.Stream);
     assert.ok(pipe.writer instanceof events.EventEmitter);
-
-    new Pipe(false);
-    new Pipe(true);
 }
 
 /**
@@ -70,11 +67,12 @@ function noWritePaused() {
     testWith("destroySoon");
 
     function testWith(enderName) {
-        var pipe = new Pipe(true);
+        var pipe = new Pipe();
         var coll = new EventCollector();
 
         coll.listenAllCommon(pipe.reader);
         coll.listenAllCommon(pipe.writer);
+        pipe.reader.pause();
 
         assert.equal(coll.events.length, 0);
         pipe.writer[enderName].call(pipe.writer);
@@ -253,7 +251,8 @@ function readableTransition() {
     // writer, and ensure the reader is still readable before the
     // resume() happens.
 
-    pipe = new Pipe(true);
+    pipe = new Pipe();
+    pipe.reader.pause();
     pipe.writer.end("blort");
     assert.ok(pipe.reader.readable);
     pipe.reader.resume();


### PR DESCRIPTION
It was pretty pointless. The two constructors that take a `paused`
argument do so because it's sensible for them to start out paused, but
it seemed odd to mandate it.

Originally, I thought all the constructors in the module would have
`paused` arguments, but that idea fell by the wayside.

This change now makes things consistent in that, if there _is_ a
`paused` argument, the default is always `true`.

/cc @mikefleming 
/cc @dpup 

R=mike
R=dan
