### PR TITLE
Danfuzz pause default

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ producing `false` for `cat.readable`).
 
 If the optional `paused` argument is specified, it indicates whether
 or not the new instance should start out in the paused state. It defaults
-to `true`, because that's the overwhelmingly most common use case.
+to `false`. That said, the constructor argument is provided because it's
+pretty common to want to start instances out paused.
 
 The constructed instance obeys the full standard Node stream protocol
 for readers, except that `setEncoding()` throws when called. This
@@ -553,7 +554,8 @@ Constructs and returns a new valve, which listens to the given source.
 
 If the optional `paused` argument is specified, it indicates whether
 or not the new instance should start out in the paused state. It defaults
-to `true`, because that's the overwhelmingly most common use case.
+to `false`. That said, the constructor argument is provided because it's
+pretty common to want to start instances out paused.
 
 The constructed instance obeys the full standard Node stream protocol
 for readers, except that `setEncoding()` throws when called. This

--- a/lib/cat.js
+++ b/lib/cat.js
@@ -33,7 +33,7 @@ var Valve = require("./valve").Valve;
 function State(emitter, streams, paused) {
   this.emitter = emitter;
   this.streams = [];
-  this.paused = typ.isDefined(paused) ? !!paused : true;
+  this.paused = typ.isDefined(paused) ? !!paused : false;
   this.readable = true;
 
   // We `bind()` the event listener callback methods, so that they

--- a/lib/valve.js
+++ b/lib/valve.js
@@ -35,7 +35,7 @@ function State(emitter, source, paused) {
 
   this.emitter = emitter;
   this.source = source;
-  this.paused = typ.isDefined(paused) ? !!paused : true;
+  this.paused = typ.isDefined(paused) ? !!paused : false;
   this.buffer = [];
   this.ended = false;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pipette",
-    "version": "0.7.2",
+    "version": "0.8.0",
     "keywords":
         ["stream", "pipe", "buffer", "valve", "data", "event", "blip", "cat",
          "sink", "slicer", "reader", "read"],

--- a/test/cat.js
+++ b/test/cat.js
@@ -25,7 +25,7 @@ var EventCollector = require("./eventcoll").EventCollector;
 function makeErrorBlip(error) {
   var emitter = new events.EventEmitter();
 
-  var valve = new pipette.Valve(emitter);
+  var valve = new pipette.Valve(emitter, true);
   emitter.emit("error", error);
   emitter.emit("close");
 
@@ -116,7 +116,7 @@ function noDataEvents() {
       blips.push(blip);
     }
 
-    var cat = new Cat(blips);
+    var cat = new Cat(blips, true);
     var coll = new EventCollector();
 
     for (var i = 0; i < count; i++) {
@@ -146,7 +146,7 @@ function basicEventSequence() {
       blips.push(new pipette.Blip("" + i));
     }
 
-    var cat = new Cat(blips);
+    var cat = new Cat(blips, true);
     var coll = new EventCollector();
 
     for (var i = 0; i < count; i++) {
@@ -188,7 +188,7 @@ function basicErrorEventSequence() {
       }
     }
 
-    var cat = new Cat(blips);
+    var cat = new Cat(blips, true);
     var coll = new EventCollector();
 
     for (var i = 0; i < blips.length; i++) {
@@ -214,7 +214,7 @@ function basicErrorEventSequence() {
  * afterwards. Also, check that it becomes false after an error.
  */
 function readableTransition() {
-  var cat = new Cat([]);
+  var cat = new Cat([], true);
 
   assert.ok(cat.readable);
   cat.resume();
@@ -222,7 +222,7 @@ function readableTransition() {
 
   var blip = makeErrorBlip(new Error("eek"));
   var coll = new EventCollector();
-  cat = new Cat([blip]);
+  cat = new Cat([blip], true);
   coll.listenAllCommon(cat);
   blip.resume();
 
@@ -235,7 +235,7 @@ function readableTransition() {
  * Just demonstrate that we don't expect `setEncoding()` to operate.
  */
 function setEncoding() {
-  var cat = new Cat([]);
+  var cat = new Cat([], true);
 
   function f() {
     cat.setEncoding("ascii");
@@ -248,7 +248,7 @@ function setEncoding() {
  * Ensure that no events get passed after a `destroy()` call.
  */
 function afterDestroy() {
-  var cat = new Cat([]);
+  var cat = new Cat([], true);
   var coll = new EventCollector();
 
   coll.listenAllCommon(cat);

--- a/test/valve.js
+++ b/test/valve.js
@@ -58,7 +58,7 @@ function needSource() {
  */
 function noInitialEvents() {
   var source = new events.EventEmitter();
-  var valve = new Valve(source);
+  var valve = new Valve(source, true);
   var coll = new EventCollector();
 
   coll.listenAllCommon(valve);
@@ -76,7 +76,7 @@ function readableTransition() {
 
   function tryWith(name, arg) {
     var source = new events.EventEmitter();
-    var valve = new Valve(source);
+    var valve = new Valve(source, true);
     var coll = new EventCollector();
 
     coll.listenAllCommon(valve);
@@ -116,7 +116,7 @@ function eventsAfterClose() {
 
   function tryWith(doError, name, arg) {
     var source = new events.EventEmitter();
-    var valve = new Valve(source, false);
+    var valve = new Valve(source);
     var coll = new EventCollector();
 
     coll.listenAllCommon(valve);
@@ -157,7 +157,7 @@ function bufferDataEvents() {
 
   function tryWith(count) {
     var source = new events.EventEmitter();
-    var valve = new Valve(source);
+    var valve = new Valve(source, true);
     var coll = new EventCollector();
 
     coll.listenAllCommon(valve);
@@ -190,7 +190,7 @@ function bufferEnders() {
 
   function tryWith(name, arg) {
     var source = new events.EventEmitter();
-    var valve = new Valve(source);
+    var valve = new Valve(source, true);
     var coll = new EventCollector();
 
     coll.listenAllCommon(valve);
@@ -219,7 +219,7 @@ function bufferEnders() {
  */
 function eventsAfterResume() {
   var source = new events.EventEmitter();
-  var valve = new Valve(source);
+  var valve = new Valve(source, true);
   var coll = new EventCollector();
 
   coll.listenAllCommon(valve);
@@ -248,7 +248,7 @@ function closeWithoutPayload() {
 
   function tryWith(payload) {
     var source = new events.EventEmitter();
-    var valve = new Valve(source, false);
+    var valve = new Valve(source);
     var coll = new EventCollector();
 
     coll.listenAllCommon(valve);
@@ -271,7 +271,7 @@ function closeWithPayload() {
 
   function tryWith(payload) {
     var source = new events.EventEmitter();
-    var valve = new Valve(source, false);
+    var valve = new Valve(source);
     var coll = new EventCollector();
 
     coll.listenAllCommon(valve);
@@ -302,7 +302,7 @@ function setEncoding() {
  */
 function afterDestroy() {
   var source = new events.EventEmitter();
-  var valve = new Valve(source, false);
+  var valve = new Valve(source);
   var coll = new EventCollector();
 
   coll.listenAllCommon(valve);
@@ -325,7 +325,7 @@ function afterDestroy() {
  */
 function destroyDuringResume() {
   var source = new events.EventEmitter();
-  var valve = new Valve(source);
+  var valve = new Valve(source, true);
   var coll = new EventCollector();
 
   coll.listenAllCommon(valve);


### PR DESCRIPTION
This switches the default `paused` argument on `Cat` and `Valve` from `false` to `true`. See docs and the main commit for details.

/cc @azulus because I think he's interested.

I'm not going to wait for review, since this is pretty straightforward and I want to move on to adjusting the dependent code. As always, I'm happy to do post-merge tweaks as needed.
