### PR TITLE
Unexpectedly short reads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,10 @@ consistently called as `callback(error, length, buffer, offset)` with
 arguments defined as follows:
 
 * `error` -- a boolean flag indicating whether the read was cut short
-  due to an error. (Note: This is different than `fs.read()` which
-  passes an error object here. See `slicer.gotError()` below for an
-  explanation of the difference.)
+  due to an error *or* because there was insufficient data to fully
+  comply with the request. (Note: This is different than `fs.read()`
+  which passes an error object here. See `slicer.gotError()` below for
+  an explanation of why.)
 
 * `length` -- the number of bytes read.
 
@@ -509,7 +510,8 @@ Reads as much data as possible from the stream, blocking the callback
 
 To be clear, if there is no data available in the slicer at the time
 this read becomes potentially-serviced, then it will in fact get
-serviced, with the callback indicating that zero bytes were read.
+serviced, with the callback indicating that zero bytes were read
+without error.
 
 The `buffer` in the callback will always be a freshly-allocated buffer
 that does not share its data with any other instance.
@@ -526,7 +528,8 @@ sequence of callbacks coming from this instance.
 
 To be clear, the callback will only ever indicate a shorter `length`
 than requested if the upstream source ends without at least `length`
-bytes being available.
+bytes being available. If a short read ends up happening, then the
+callback will get passed `true` for the error flag.
 
 The `buffer` in the callback will always be a freshly-allocated buffer
 that does not share its data with any other instance.
@@ -543,6 +546,11 @@ If `length` is passed as `undefined` it means "read as much as
 possible without blocking". This is different than passing `0` which
 means simply "read zero bytes". (This latter case can actually be
 useful. See `slicer.read(length, callback)` above.)
+
+As with `read()`, the only time the length will be shorter than what
+was requested will be if the stream ends without there being at least
+`length` bytes to read. If a short read ends up happening, then the
+callback will get passed `true` for the error flag.
 
 
 Valve

--- a/lib/slicer.js
+++ b/lib/slicer.js
@@ -61,9 +61,10 @@ PendingRead.prototype.trigger = function trigger(state, force) {
   var length = this.length;
   var buffers = state.buffers;
   var bufferedLength = state.bufferedLength;
+  var error = false;
 
   // High-order bit #1: If the request is for zero bytes, satisfy it
-  // trivially. We do this above the error check, because it makes
+  // trivially. We do this before the error check, because it makes
   // sense to let such requests succeed, even in the face of a pending
   // error.
   if (length === 0) {
@@ -96,6 +97,7 @@ PendingRead.prototype.trigger = function trigger(state, force) {
     }
     // We're being forced; just read what's available.
     length = bufferedLength;
+    error = true;
   }
 
   // Copy the right amount out of the pending buffers.
@@ -131,7 +133,7 @@ PendingRead.prototype.trigger = function trigger(state, force) {
   }
 
   state.bufferedLength = bufferedLength; // Write back modified value.
-  this.callback(false, endOffset - origOffset, buffer, origOffset);
+  this.callback(error, endOffset - origOffset, buffer, origOffset);
   return true;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pipette",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "keywords":
         ["stream", "pipe", "buffer", "valve", "data", "event", "blip", "cat",
          "sink", "slicer", "reader", "read"],

--- a/test/slicer.js
+++ b/test/slicer.js
@@ -133,9 +133,9 @@ function destroy() {
     assert.equal(source.listeners("end").length, 0);
     assert.equal(source.listeners("error").length, 0);
 
-    coll.assertCallback(0, false, theData.length, theData, 0);
+    coll.assertCallback(0, true, theData.length, theData, 0);
     for (var i = 1; i < count; i++) {
-      coll.assertCallback(i, false, 0, new Buffer(0), 0);
+      coll.assertCallback(i, true, 0, new Buffer(0), 0);
     }
   }
 }
@@ -454,14 +454,16 @@ function partialRead() {
 
     slicer.read(1000, coll.callback);
     slicer.read(1, coll.callback);
+    slicer.readAll(coll.callback);
     source.emit("data", theData);
     assert.equal(coll.callbacks.length, 0);
 
     emit(source, endEvent, endArg);
-    assert.equal(coll.callbacks.length, 2);
+    assert.equal(coll.callbacks.length, 3);
 
-    coll.assertCallback(0, false, theData.length, theData, 0);
-    coll.assertCallback(1, expectError, 0, new Buffer(0), 0);
+    coll.assertCallback(0, true, theData.length, theData, 0);
+    coll.assertCallback(1, true, 0, new Buffer(0), 0);
+    coll.assertCallback(2, expectError, 0, new Buffer(0), 0);
   }
 }
 
@@ -554,11 +556,11 @@ function noCallbackReuse() {
 
   for (i = 0; i < colls.length; i++) {
     var one = colls[i];
-    var expectBuf =
-      (i < theData.length) ? theData.slice(i, i + 1) : new Buffer(0);
+    var expectError = (i >= theData.length);
+    var expectBuf = expectError ? new Buffer(0) : theData.slice(i, i + 1);
 
     assert.equal(one.callbacks.length, 1);
-    one.assertCallback(0, false, expectBuf.length, expectBuf, 0);
+    one.assertCallback(0, expectError, expectBuf.length, expectBuf, 0);
   }
 }
 


### PR DESCRIPTION
These now cause the callback `error` argument to be passed as `true`.

This simplifies use cases, in that they can check `error` to see if
anything special is warranted, rather than having to check both that
_and_ the result length.

/cc @azulus 
/cc @guitardave24 

R=jeremy
R=david
