### PR TITLE
Proper `this` hygiene in callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ that came in as `data` events.
 Most of the "interesting" methods on the class take a callback
 argument to receive data back from the instance. These are all
 consistently called as `callback(error, length, buffer, offset)` with
-arguments defined as follows:
+no `this` and with arguments defined as follows:
 
 * `error` -- a boolean flag indicating whether the read was cut short
   due to an error *or* because there was insufficient data to fully

--- a/lib/slicer.js
+++ b/lib/slicer.js
@@ -68,14 +68,14 @@ PendingRead.prototype.trigger = function trigger(state, force) {
   // sense to let such requests succeed, even in the face of a pending
   // error.
   if (length === 0) {
-    this.callback(false, 0, buffer || new Buffer(0), offset);
+    this.callCallback(false, 0, buffer || new Buffer(0), offset);
     return true;
   }
 
   // High-order bit #2: If the slicer is in an error state and there's
   // nothing to read first, report the error.
   if ((bufferedLength === 0) && (state.error !== consts.NO_ERROR)) {
-    this.callback(true, 0, buffer || new Buffer(0), offset);
+    this.callCallback(true, 0, buffer || new Buffer(0), offset);
     return true;
   }
 
@@ -133,8 +133,17 @@ PendingRead.prototype.trigger = function trigger(state, force) {
   }
 
   state.bufferedLength = bufferedLength; // Write back modified value.
-  this.callback(error, endOffset - origOffset, buffer, origOffset);
+  this.callCallback(error, endOffset - origOffset, buffer, origOffset);
   return true;
+}
+
+/**
+ * Calls the `callback` with the given arguments and with *no* defined
+ * `this`.
+ */
+PendingRead.prototype.callCallback =
+function callCallback(error, count, buffer, offset) {
+  this.callback.call(undefined, error, count, buffer, offset);
 }
 
 Object.freeze(PendingRead);

--- a/test/slicer.js
+++ b/test/slicer.js
@@ -571,6 +571,7 @@ function noCallbackReuse() {
 function callbackThis() {
   var source = new events.EventEmitter();
   var slicer = new Slicer(source);
+  var count = 0;
 
   source.emit("data", "sufficiently tasty muffins");
 
@@ -590,7 +591,10 @@ function callbackThis() {
   slicer.readAll(callback);
   slicer.readInto(new Buffer(1), 0, 1, callback);
 
+  assert.equal(count, 9, "Missing callback.");
+
   function callback(/*ignored*/) {
+    count++;
     assert.equal(this, undefined, "Bogus `this` in callback.");
   }
 }

--- a/test/slicer.js
+++ b/test/slicer.js
@@ -564,6 +564,37 @@ function noCallbackReuse() {
   }
 }
 
+/**
+ * Makes sure that callbacks aren't called with anything other than
+ * a default `this`.
+ */
+function callbackThis() {
+  var source = new events.EventEmitter();
+  var slicer = new Slicer(source);
+
+  source.emit("data", "sufficiently tasty muffins");
+
+  // These are meant to cover all the various ways a callback might be
+  // triggered.
+
+  slicer.read(1, callback);
+  slicer.read(0, callback);
+  slicer.readInto(new Buffer(5), 0, 5, callback);
+  slicer.readAll(callback);
+  slicer.read(0, callback);
+
+  source.emit("error", new Error("Insufficient tastiness after all!"));
+
+  slicer.read(0, callback);
+  slicer.read(1, callback);
+  slicer.readAll(callback);
+  slicer.readInto(new Buffer(1), 0, 1, callback);
+
+  function callback(/*ignored*/) {
+    assert.equal(this, undefined, "Bogus `this` in callback.");
+  }
+}
+
 function test() {
   constructor();
   constructorFailures();
@@ -580,6 +611,7 @@ function test() {
   constructorEncodings();
   setIncomingEncoding();
   noCallbackReuse();
+  callbackThis();
 }
 
 module.exports = {


### PR DESCRIPTION
Always make callbacks with `this` specified as `undefined`, to avoid
leaking an internal object.

/cc @guitardave24 
/cc @azulus 

R=david
R=jeremy
