### PR TITLE
testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,25 +221,36 @@ buffers, using a specified and settable incoming encoding.
 The only exception to the block size is that the last `data` event
 from a Dropper may have a smaller size, if the last data it received
 (before an `end` or `error`) would not end up filling up a block of
-the specified size. In this case, if the stream didn't end because of
-any other error, the penultimate event from the Dropper instance
-(before the `close`) will be an error indicating `"Partial buffer at
-end."`.
+the specified size. In this case, the behavior is specified by
+the `ifPartial` option (see below).
 
 Other than the fixed-size block part, the semantics of this class are
 basically the same as the simpler `Valve` class (see below).
 
-### var dropper = new Dropper(source, blockSize, [allowMultiple])
+### var dropper = new Dropper(source, options)
 
 Constructs and returns a new dropper, which listens to the given source.
+This takes an optional `options` argument, which if present must be
+a map of any of the following:
 
-The `blockSize` (must be a positive integer) indicates the number of bytes
-in each block / drop. The optional `allowMultiple` argument (defaults
-to `false`) indicates whether (`true`) or not (`false`) `data` events
-may be multiples of the block size in length.
+* `size` &mdash; block (aka drop) size in bytes. Must be a positive
+  integer. Defaults to `1`.
+
+* `allowMultiple` &mdash; whether emitted data events are to be the
+   exact block size (`false`) or may be an even multiple of the block
+   size (`true`). Must be a boolean. Defaults to `false`.
+
+ * `ifPartial` &mdash; what to do with a partial block at the
+   end of the stream; one of `emit` (emit it as-is),
+   `ignore` (drop it entirely), `pad` (zero-pad), `error` (emit
+   an error). Defaults to `emit`.
 
 The constructed instance obeys the full standard Node stream protocol
 for readers.
+
+(Note: As of this writing, this is the only one of the classes in this
+module that takes an options object on construction. It is likely that
+the rest of the classes will migrate to this form.)
 
 ### dropper.setIncomingEncoding(name)
 
@@ -650,7 +661,10 @@ containing a string payload.
 To Do
 -----
 
-* Come up with something to do.
+* Use `options` arguments consistently on construction.
+
+* Make `encoding`, `incomingEncoding`, and `paused` all be available
+  as constructor options.
 
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -301,9 +301,10 @@ using the named encoding.
 If the sink received any data but has no specified encoding, this
 returns the straight buffer of data.
 
-Note that this method can return a defined (not `undefined`) value
-before the corresponding `data` event is emitted, particularly if the
-sink happens to be paused at the time the upstream stream is ended.
+Note that this method can return a defined (that is, not `undefined`)
+value before the corresponding `data` event is emitted, particularly
+if the sink happens to be paused at the time the upstream stream is
+ended.
 
 Also note that there is a bit of ambiguity with this method, in terms of
 differentiating a stream that got ended with no data ever received

--- a/README.md
+++ b/README.md
@@ -209,6 +209,54 @@ be synonymous with `"utf8"` should a `data` event be received
 containing a string payload.
 
 
+Dropper
+-------
+
+The `Dropper` class is a bufferer of readable stream events, which
+relays those events in fixed size blocks (or multiples thereof),
+a.k.a. "drops" (hence the name). It handles pause/resume semantics,
+and it will always translate incoming values that aren't buffers into
+buffers, using a specified and settable incoming encoding.
+
+The only exception to the block size is that the last `data` event
+from a Dropper may have a smaller size, if the last data it received
+(before an `end` or `error`) would not end up filling up a block of
+the specified size. In this case, if the stream didn't end because of
+any other error, the penultimate event from the Dropper instance
+(before the `close`) will be an error indicating `"Partial buffer at
+end."`.
+
+Other than the fixed-size block part, the semantics of this class are
+basically the same as the simpler `Valve` class (see below).
+
+### var dropper = new Dropper(source, blockSize, [allowMultiple])
+
+Constructs and returns a new dropper, which listens to the given source.
+
+The `blockSize` (must be a positive integer) indicates the number of bytes
+in each block / drop. The optional `allowMultiple` argument (defaults
+to `false`) indicates whether (`true`) or not (`false`) `data` events
+may be multiples of the block size in length.
+
+The constructed instance obeys the full standard Node stream protocol
+for readers.
+
+### dropper.setIncomingEncoding(name)
+
+Sets the incoming encoding of the stream. This is the encoding to use
+when interpreting strings that arrive in `data` events. (This is as
+opposed to the encoding set by `setEncoding()` which determines how
+the collected data is transformed as it gets emitted from an
+instance.)
+
+The `name` must be one of the unified allowed encoding names for
+`Stream.setEncoding()`.
+
+The incoming encoding starts out as `undefined`, which is taken to
+be synonymous with `"utf8"` should a `data` event be received
+containing a string payload.
+
+
 Pipe
 ----
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ If the sink received any data and has a specified encoding (via
 `setEncoding()`), this returns the string form of the data, as decoded
 using the named encoding.
 
-If the sink received and data but has no specified encoding, this
+If the sink received any data but has no specified encoding, this
 returns the straight buffer of data.
 
 Note that this method can return a defined (not `undefined`) value

--- a/README.md
+++ b/README.md
@@ -111,6 +111,30 @@ Details: If a given source is a `Stream` per se, then the value of
 considered to be ended if and only if it (or a prototype in its chain)
 defines a `readable` property and that property's value is falsey.
 
+### Constructing stacked readers
+
+Many Node stream classes are designed as an atomic unit that includes
+both reader and writer methods intermingled in a single object. This
+module takes a different tack:
+
+* Any given object is either a reader or a writer, never both.
+
+* To pass one reader's event output to another, construct the destination
+  object passing it the source, e.g. `new Valve(new OtherStream(...))`.
+
+### Getting a writer
+
+If you need to get a writer to write into one of the reader classes
+(or a stack of same), you can use a `Pipe`:
+
+```javascript
+var pipe = new Pipe();
+var readerStack = new OtherStream(pipe.reader);
+var writer = pipe.writer;
+
+writer.write(...); // What's written here will get read by the OtherStream.
+```
+
 
 A Note About Encodings
 ----------------------

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ the `ifPartial` option (see below).
 Other than the fixed-size block part, the semantics of this class are
 basically the same as the simpler `Valve` class (see below).
 
-### var dropper = new Dropper(source, options)
+### var dropper = new Dropper(source, [options])
 
 Constructs and returns a new dropper, which listens to the given source.
 This takes an optional `options` argument, which if present must be

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ a map of any of the following:
    exact block size (`false`) or may be an even multiple of the block
    size (`true`). Must be a boolean. Defaults to `false`.
 
- * `ifPartial` &mdash; what to do with a partial block at the
+* `ifPartial` &mdash; what to do with a partial block at the
    end of the stream; one of `emit` (emit it as-is),
    `ignore` (drop it entirely), `pad` (zero-pad), `error` (emit
    an error). Defaults to `emit`.
@@ -684,6 +684,9 @@ Author
 [Dan Bornstein](https://github.com/danfuzz)
 ([personal website](http://www.milk.com/)), supported by
 [The Obvious Corporation](http://obvious.com/).
+
+Thanks to <https://github.com/rootslab/dropper> for the name of the
+`Dropper` class.
 
 
 License

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ encodings specified by those. This includes:
 * `utf16le` &mdash; standard little-endian UTF-16 encoding for Unicode data
 * `utf8` &mdash; standard UTF-8 encoding for Unicode data
 
+
 * * * * * * * * * *
 
 API Details

--- a/README.md
+++ b/README.md
@@ -119,14 +119,14 @@ Node 0.6.* and 0.8.* differ in their documentation about which encodings
 are allowed by `setEncoding()`. This module accepts the union of the
 encodings specified by those. This includes:
 
-* `ascii` -- 7-bit ASCII
-* `base64` -- standard Base-64 encoding for binary data
-* `hex` -- hex encoding for binary data (two hexadecimal ASCII
+* `ascii` &mdash; 7-bit ASCII
+* `base64` &mdash; standard Base-64 encoding for binary data
+* `hex` &mdash; hex encoding for binary data (two hexadecimal ASCII
   characters per byte)
-* `ucs2` -- alias for `utf16le` (below). This is not technically correct
+* `ucs2` &mdash; alias for `utf16le` (below). This is not technically correct
   (per Unicode spec), but it is how Node is defined.
-* `utf16le` -- standard little-endian UTF-16 encoding for Unicode data
-* `utf8` -- standard UTF-8 encoding for Unicode data
+* `utf16le` &mdash; standard little-endian UTF-16 encoding for Unicode data
+* `utf8` &mdash; standard UTF-8 encoding for Unicode data
 
 * * * * * * * * * *
 
@@ -378,17 +378,17 @@ argument to receive data back from the instance. These are all
 consistently called as `callback(error, length, buffer, offset)` with
 no `this` and with arguments defined as follows:
 
-* `error` -- a boolean flag indicating whether the read was cut short
+* `error` &mdash; a boolean flag indicating whether the read was cut short
   due to an error *or* because there was insufficient data to fully
   comply with the request. (Note: This is different than `fs.read()`
   which passes an error object here. See `slicer.gotError()` below for
   an explanation of why.)
 
-* `length` -- the number of bytes read.
+* `length` &mdash; the number of bytes read.
 
-* `buffer` -- the buffer that was read into.
+* `buffer` &mdash; the buffer that was read into.
 
-* `offset` -- the offset into `buffer` where the reading was done.
+* `offset` &mdash; the offset into `buffer` where the reading was done.
 
 The ordering and meaning of the callback arguments are meant to be (a)
 compatible with callbacks used with `fs.read()` and (b) somewhat more

--- a/lib/dropper.js
+++ b/lib/dropper.js
@@ -32,7 +32,11 @@ function State(emitter, source, blockSize, allowMultiple) {
   /** Outer emitter. */
   this.emitter = emitter;
 
-  /** Upstream source, wrapped in a Valve to provide saner semantics. */
+  /**
+   * Upstream source, wrapped in a Valve to provide saner semantics as
+   * well as the actual implementation of `pause()`, `resume()` and
+   * `setIncomingEncoding()`.
+   */
   this.source = new Valve(source);
 
   /** Desired size of each emitted block, in bytes. */
@@ -219,6 +223,10 @@ Dropper.prototype.resume = function resume() {
 
 Dropper.prototype.setEncoding = function setEncoding(name) {
   sealer.unseal(this.dropper).decoder.setEncoding(name);
+};
+
+Dropper.prototype.setIncomingEncoding = function setIncomingEncoding(name) {
+  sealer.unseal(this.dropper).source.setIncomingEncoding(name);
 };
 
 Object.defineProperty(

--- a/lib/dropper.js
+++ b/lib/dropper.js
@@ -74,7 +74,7 @@ State.prototype.destroy = function destroy() {
  * if necessary.
  */
 State.prototype.emitData = function emitData(data) {
-  this.emit(consts.DATA, decoder.decode(data));
+  this.emitter.emit(consts.DATA, decoder.decode(data));
 }
 
 /**
@@ -99,13 +99,15 @@ State.prototype.emitFinalEvents = function emitFinalEvents(gotError, error) {
     }
   }
 
+  var emitter = this.emitter;
+
   if (gotError) {
-    this.emit(consts.ERROR, error);
+    emitter.emit(consts.ERROR, error);
   } else {
-    this.emit(consts.END);
+    emitter.emit(consts.END);
   }
 
-  this.emit(consts.CLOSE);
+  emitter.emit(consts.CLOSE);
   this.destroy();
 }
 

--- a/lib/dropper.js
+++ b/lib/dropper.js
@@ -78,7 +78,7 @@ State.prototype.destroy = function destroy() {
  * if necessary.
  */
 State.prototype.emitData = function emitData(data) {
-  this.emitter.emit(consts.DATA, decoder.decode(data));
+  this.emitter.emit(consts.DATA, this.decoder.decode(data));
 }
 
 /**

--- a/lib/dropper.js
+++ b/lib/dropper.js
@@ -15,8 +15,10 @@ var stream = require("stream");
 var typ = require("typ");
 var util = require("util");
 
+var Codec = require("./codec").Codec;
 var consts = require("./consts");
 var sealer = require("./sealer");
+var Valve = require("./valve").Valve;
 
 
 /*
@@ -48,7 +50,7 @@ function State(emitter, source, blockSize, allowMultiple) {
   // We `bind()` the event listener callback methods, so that they
   // get an appropriate `this` when they're called during event
   // emission.
-  this.onCloseOrEnd = this.onClose.bind(this);
+  this.onCloseOrEnd = this.onCloseOrEnd.bind(this);
   this.onData = this.onData.bind(this);
   this.onError = this.onError.bind(this);
 

--- a/lib/dropper.js
+++ b/lib/dropper.js
@@ -37,7 +37,7 @@ function State(emitter, source, blockSize, allowMultiple) {
    * well as the actual implementation of `pause()`, `resume()` and
    * `setIncomingEncoding()`.
    */
-  this.source = new Valve(source);
+  this.source = source = new Valve(source);
 
   /** Desired size of each emitted block, in bytes. */
   this.blockSize = blockSize;

--- a/lib/dropper.js
+++ b/lib/dropper.js
@@ -22,13 +22,30 @@ var Valve = require("./valve").Valve;
 
 
 /*
+ * Module variables
+ */
+
+/** Constant for `ifPartial` */
+var EMIT = "emit";
+
+/** Constant for `ifPartial` */
+var ERROR = "error";
+
+/** Constant for `ifPartial` */
+var IGNORE = "ignore";
+
+/** Constant for `ifPartial` */
+var PAD = "pad";
+
+
+/*
  * Helper functions
  */
 
 /**
  * Construct a Dropper state object.
  */
-function State(emitter, source, blockSize, allowMultiple) {
+function State(emitter, source, blockSize, allowMultiple, ifPartial) {
   /** Outer emitter. */
   this.emitter = emitter;
 
@@ -44,6 +61,9 @@ function State(emitter, source, blockSize, allowMultiple) {
 
   /** Whether multiples of the block size are allowed. */
   this.allowMultiple = allowMultiple;
+
+  /** What to do with a partial block at the end of the stream. */
+  this.ifPartial = ifPartial;
 
   /** The encoding to use when emitting events. */
   this.decoder = new Codec();
@@ -94,12 +114,31 @@ State.prototype.emitFinalEvents = function emitFinalEvents(gotError, error) {
 
   var data = this.pendingData;
   if (data && (data.length !== 0)) {
-    this.emitData(data);
-    if (!gotError) {
-      // There was no "larger" error, so just indicate the short
-      // buffer as the error.
-      gotError = true;
-      error = new Error("Partial buffer at end.");
+    switch (this.ifPartial) {
+      case EMIT: {
+        this.emitData(data);
+        break;
+      }
+      case ERROR: {
+        if (!gotError) {
+          // There was no "larger" error, so just indicate the short
+          // buffer as the error.
+          gotError = true;
+          error = new Error("Partial buffer at end.");
+        }
+        break;
+      }
+      case IGNORE: {
+        // Do nothing.
+        break;
+      }
+      case PAD: {
+        var newData = new Buffer(this.blockSize);
+        data.copy(newData);
+        newData.fill(0, data.length);
+        this.emitData(newData);
+        break;
+      }
     }
   }
 
@@ -185,16 +224,20 @@ Object.freeze(State.prototype);
  * Constructs a Dropper instance, which reemits data in fixed-size
  * blocks (aka drops). Dropper instances are in turn instances of
  * `stream.Stream`.
- *
- * `blockSize` indicates the block size in bytes. `allowMultiple`
- * (defaults to `false`) indicates whether blocks must be exactly
- * the block size (`false`) or may be even multiples of the block
- * size (`true`).
  */
-function Dropper(source, blockSize, allowMultiple) {
-  typ.assertUInt(blockSize);
-  if (blockSize === 0) {
-    throw new Error("Invalid block size.");
+function Dropper(source, options) {
+  options = options || {};
+  var blockSize = options.size;
+  var allowMultiple = options.allowMultiple;
+  var ifPartial = options.ifPartial;
+
+  if (typ.isDefined(blockSize)) {
+    typ.assertUInt(blockSize);
+    if (blockSize === 0) {
+      throw new Error("Expected uint > 0.");
+    }
+  } else {
+    blockSize = 1;
   }
 
   if (typ.isDefined(allowMultiple)) {
@@ -203,8 +246,27 @@ function Dropper(source, blockSize, allowMultiple) {
     allowMultiple = false;
   }
 
+  switch (ifPartial) {
+    case EMIT:
+    case ERROR:
+    case IGNORE:
+    case PAD: {
+      // These are the valid choices.
+      break;
+    }
+    case undefined: {
+      // This is the default;
+      ifPartial = EMIT;
+      break;
+    }
+    default: {
+      throw new Error("Bad ifPartial value: " + ifPartial);
+    }
+  }
+
   stream.Stream.call(this);
-  this.dropper = sealer.seal(new State(this, source, blockSize, allowMultiple));
+  this.dropper = sealer.seal(
+    new State(this, source, blockSize, allowMultiple, ifPartial));
 }
 
 util.inherits(Dropper, stream.Stream);

--- a/lib/dropper.js
+++ b/lib/dropper.js
@@ -1,0 +1,233 @@
+// Copyright 2012 The Obvious Corporation.
+
+/*
+ * A stream filter which re-emits data it receives in fixed-size chunks.
+ */
+
+
+/*
+ * Modules used
+ */
+
+"use strict";
+
+var stream = require("stream");
+var typ = require("typ");
+var util = require("util");
+
+var consts = require("./consts");
+var sealer = require("./sealer");
+
+
+/*
+ * Helper functions
+ */
+
+/**
+ * Construct a Dropper state object.
+ */
+function State(emitter, source, blockSize, allowMultiple) {
+  /** Outer emitter. */
+  this.emitter = emitter;
+
+  /** Upstream source, wrapped in a Valve to provide saner semantics. */
+  this.source = new Valve(source);
+
+  /** Desired size of each emitted block, in bytes. */
+  this.blockSize = blockSize;
+
+  /** Whether multiples of the block size are allowed. */
+  this.allowMultiple = allowMultiple;
+
+  /** The encoding to use when emitting events. */
+  this.decoder = new Codec();
+
+  /** Current pending data (if any) */
+  this.pendingData = undefined;
+
+  // We `bind()` the event listener callback methods, so that they
+  // get an appropriate `this` when they're called during event
+  // emission.
+  this.onCloseOrEnd = this.onClose.bind(this);
+  this.onData = this.onData.bind(this);
+  this.onError = this.onError.bind(this);
+
+  source.on(consts.CLOSE, this.onCloseOrEnd);
+  source.on(consts.DATA, this.onData);
+  source.on(consts.END, this.onCloseOrEnd);
+  source.on(consts.ERROR, this.onError);
+}
+
+State.prototype.destroy = function destroy() {
+  // Destroy the source (our private Valve), but don't un-define it,
+  // so that other calls (particularly `isReadable()`) can work
+  // straightforwardly.
+  this.source.destroy();
+
+  this.emitter = undefined;
+}
+
+/**
+ * Emits a `data` event for the given payload. This does decoding
+ * if necessary.
+ */
+State.prototype.emitData = function emitData(data) {
+  this.emit(consts.DATA, decoder.decode(data));
+}
+
+/**
+ * Emits final `data` event (if any), then the end event sequence. Note:
+ * `gotError` is needed as separate from `error` because we might have
+ * received an `error` event with `undefined` payload.
+ */
+State.prototype.emitFinalEvents = function emitFinalEvents(gotError, error) {
+  if (!this.emitter) {
+    // This may be due to an extra event that squeaked by.
+    return;
+  }
+
+  var data = this.pendingData;
+  if (data && (data.length !== 0)) {
+    this.emitData(data);
+    if (!gotError) {
+      // There was no "larger" error, so just indicate the short
+      // buffer as the error.
+      gotError = true;
+      error = new Error("Partial buffer at end.");
+    }
+  }
+
+  if (gotError) {
+    this.emit(consts.ERROR, error);
+  } else {
+    this.emit(consts.END);
+  }
+
+  this.emit(consts.CLOSE);
+  this.destroy();
+}
+
+State.prototype.isReadable = function isReadable() {
+  return this.source.readable;
+}
+
+State.prototype.onCloseOrEnd = function onCloseOrEnd() {
+  this.emitFinalEvents(false);
+}
+
+State.prototype.onData = function onData(data) {
+  var pendingData = this.pendingData;
+  if (pendingData && (pendingData.length !== 0)) {
+    if (data.length == 0) {
+      // Empty incoming data. Nothing more to do.
+      return;
+    }
+
+    // Append the new data to the pending data.
+    var newLength = pendingData.length + data.length;
+    var newData = new Buffer(newLength);
+    pendingData.copy(newData);
+    data.copy(newData, pendingData.length);
+    data = newData;
+    this.pendingData = undefined;
+  }
+
+  var length = data.length;
+  var blockSize = this.blockSize;
+
+  if (length < blockSize) {
+    // Not enough data to emit anything.
+    this.pendingData = data;
+    return;
+  }
+
+  // Save the part of the data that won't be emitted (if any) as
+  // `pendingData` ready for the next `data` event.
+  var leftoverLength = length % blockSize;
+  if (leftoverLength !== 0) {
+    length -= leftoverLength;
+    this.pendingData = data.slice(length);
+    data = data.slice(0, length);
+  }
+
+  if (this.allowMultiple) {
+    // Just emit a single `data` event for all the data.
+    this.emitData(data);
+  } else {
+    // Emit as many `data` events as are needed.
+    for (var i = 0; i < length; i += blockSize) {
+      this.emitData(data.slice(i, i + blockSize));
+    }
+  }
+}
+
+State.prototype.onError = function onError(error) {
+  this.emitFinalEvents(true, error);
+}
+
+Object.freeze(State);
+Object.freeze(State.prototype);
+
+
+/*
+ * Exported bindings
+ */
+
+/**
+ * Constructs a Dropper instance, which reemits data in fixed-size
+ * blocks (aka drops). Dropper instances are in turn instances of
+ * `stream.Stream`.
+ *
+ * `blockSize` indicates the block size in bytes. `allowMultiple`
+ * (defaults to `false`) indicates whether blocks must be exactly
+ * the block size (`false`) or may be even multiples of the block
+ * size (`true`).
+ */
+function Dropper(source, blockSize, allowMultiple) {
+  typ.assertUInt(blockSize);
+  if (blockSize === 0) {
+    throw new Error("Invalid block size.");
+  }
+
+  if (typ.isDefined(allowMultiple)) {
+    typ.assertBoolean(allowMultiple);
+  } else {
+    allowMultiple = false;
+  }
+
+  stream.Stream.call(this);
+  this.dropper = sealer.seal(new State(this, source, blockSize, allowMultiple));
+}
+
+util.inherits(Dropper, stream.Stream);
+
+Dropper.prototype.destroy = function destroy() {
+  sealer.unseal(this.dropper).destroy();
+};
+
+Dropper.prototype.pause = function pause() {
+  sealer.unseal(this.dropper).source.pause();
+};
+
+Dropper.prototype.resume = function resume() {
+  sealer.unseal(this.dropper).source.resume();
+};
+
+Dropper.prototype.setEncoding = function setEncoding(name) {
+  sealer.unseal(this.dropper).decoder.setEncoding(name);
+};
+
+Object.defineProperty(
+  Dropper.prototype,
+  "readable",
+  {
+    get: function() { return sealer.unseal(this.dropper).isReadable(); },
+    enumerable: true
+  });
+
+Object.freeze(Dropper);
+Object.freeze(Dropper.prototype);
+
+module.exports = {
+  Dropper: Dropper
+};

--- a/lib/pipette.js
+++ b/lib/pipette.js
@@ -7,6 +7,7 @@
 module.exports = {
   Blip: require("./blip").Blip,
   Cat: require("./cat").Cat,
+  Dropper: require("./dropper").Dropper,
   Pipe: require("./pipe").Pipe,
   Sink: require("./sink").Sink,
   Slicer: require("./slicer").Slicer,

--- a/lib/valve.js
+++ b/lib/valve.js
@@ -12,7 +12,6 @@
 
 "use strict";
 
-var assert = require("assert");
 var stream = require("stream");
 var typ = require("typ");
 var util = require("util");
@@ -181,6 +180,7 @@ State.prototype.onError = function onError(error) {
   }
 }
 
+Object.freeze(State);
 Object.freeze(State.prototype);
 
 
@@ -198,8 +198,6 @@ Object.freeze(State.prototype);
  * (because that's the expected primary use case).
  */
 function Valve(source, paused) {
-  assert.ok(typ.isDefined(source), "Missing source.");
-
   stream.Stream.call(this);
   this.valve = sealer.seal(new State(this, source, paused));
 }
@@ -235,6 +233,7 @@ Object.defineProperty(
     enumerable: true
   });
 
+Object.freeze(Valve);
 Object.freeze(Valve.prototype);
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.8.4",
     "keywords":
         ["stream", "pipe", "buffer", "valve", "data", "event", "blip", "cat",
-         "sink", "slicer", "reader", "read"],
+         "sink", "slicer", "reader", "read", "dropper"],
     "description":
         "Stream and pipe utilities for Node",
     "homepage": "https://github.com/Obvious/pipette",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pipette",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "keywords":
         ["stream", "pipe", "buffer", "valve", "data", "event", "blip", "cat",
          "sink", "slicer", "reader", "read"],

--- a/test/dropper.js
+++ b/test/dropper.js
@@ -433,11 +433,6 @@ function setIncomingEncoding() {
   }
 }
 
-
-
-
-// FIXME: Make these work.
-
 /**
  * Ensure that no events get passed after a `destroy()` call. Also,
  * proves that the dropper isn't even listening for events from the
@@ -463,26 +458,26 @@ function afterDestroy() {
 }
 
 /**
- * Ensure that things don't go haywire if a valve is destroyed in the
+ * Ensure that things don't go haywire if a dropper is destroyed in the
  * middle of being resumed.
  */
 function destroyDuringResume() {
   var theData = new Buffer("stuff");
   var source = new events.EventEmitter();
-  var valve = new Valve(source, true);
+  var dropper = new Dropper(source, 5);
   var coll = new EventCollector();
 
-  coll.listenAllCommon(valve);
+  dropper.pause();
+  coll.listenAllCommon(dropper);
   source.emit("data", theData);
   source.emit("end");
 
-  valve.on("data", function() { valve.destroy(); });
-  valve.resume();
+  dropper.on("data", function() { dropper.destroy(); });
+  dropper.resume();
 
   assert.equal(coll.events.length, 1);
-  coll.assertEvent(0, valve, "data", [theData]);
+  coll.assertEvent(0, dropper, "data", [theData]);
 }
-
 
 function test() {
   constructor();
@@ -495,11 +490,8 @@ function test() {
   bufferedSequence();
   setEncoding();
   setIncomingEncoding();
-
-  /* FIXME
   afterDestroy();
   destroyDuringResume();
-  */
 }
 
 module.exports = {

--- a/test/dropper.js
+++ b/test/dropper.js
@@ -1,0 +1,507 @@
+// Copyright 2012 The Obvious Corporation.
+
+/*
+ * Modules used
+ */
+
+"use strict";
+
+var assert = require("assert");
+var events = require("events");
+
+var Blip = require("../").Blip;
+var Dropper = require("../").Dropper;
+
+var EventCollector = require("./eventcoll").EventCollector;
+var emit = require("./emit").emit;
+
+
+/*
+ * Helper functions
+ */
+
+/**
+ * Combines two buffers.
+ */
+function addBufs(buf1, buf2) {
+  if (!buf1 || (buf1.length === 0)) {
+    return buf2;
+  }
+
+  var length = buf1.length + buf2.length;
+  var buf = new Buffer(length);
+
+  buf1.copy(buf);
+  buf2.copy(buf, buf1.length);
+  return buf;
+}
+
+
+/*
+ * Tests
+ */
+
+/**
+ * Makes sure the constructor doesn't fail off the bat.
+ */
+function constructor() {
+  new Dropper(new events.EventEmitter(), 10);
+  new Dropper(new events.EventEmitter(), 20, true);
+  new Dropper(new events.EventEmitter(), 30, false);
+}
+
+/**
+ * Tests expected constructor failures.
+ */
+function constructorFailure() {
+  function f1() {
+    new Dropper(undefined, 1);
+  }
+  assert.throws(f1, /Missing source/);
+
+  function f2() {
+    new Dropper(["hello"], 1);
+  }
+  assert.throws(f2, /Source not an EventEmitter/);
+
+  // This is an already-ended Stream-per-se.
+  var bad = new Blip();
+  bad.resume();
+
+  function f3() {
+    new Dropper(bad, 1);
+  }
+  assert.throws(f3, /Source already ended./);
+
+  function f4() {
+    new Dropper(new events.EventEmitter(), -1);
+  }
+  assert.throws(f4, /Expected uint/);
+
+  function f5() {
+    new Dropper(new events.EventEmitter(), 0);
+  }
+  assert.throws(f5, /Invalid block size/);
+
+  function f6() {
+    new Dropper(new events.EventEmitter(), "yo");
+  }
+  assert.throws(f6, /Expected uint/);
+
+  function f7() {
+    new Dropper(new events.EventEmitter(), 10, "hey");
+  }
+  assert.throws(f7, /Expected boolean/);
+}
+
+/**
+ * Tests that `readable` is true until an end-type event comes through.
+ */
+function readableTransition() {
+  tryWith("end");
+  tryWith("close");
+  tryWith("error", new Error("criminy"));
+
+  function tryWith(name, arg) {
+    var source = new events.EventEmitter();
+    var dropper = new Dropper(source, 10);
+    var coll = new EventCollector();
+
+    dropper.pause();
+    coll.listenAllCommon(dropper);
+    assert.ok(dropper.readable);
+
+    dropper.resume();
+    assert.ok(dropper.readable);
+
+    dropper.pause();
+    assert.ok(dropper.readable);
+
+    emit(source, name, arg);
+    assert.ok(dropper.readable);
+    assert.equal(coll.events.length, 0);
+
+    dropper.resume();
+    assert.equal(coll.events.length, 2);
+    assert.ok(!dropper.readable);
+  }
+}
+
+/**
+ * Tests that no events will get passed through after a close sequence
+ * (`end` or `error` followed by `close`).
+ */
+function eventsAfterClose() {
+  var theError = new Error("insufficient muffins");
+
+  tryWith(false, "data", "stuff");
+  tryWith(false, "end");
+  tryWith(false, "close");
+  tryWith(false, "error", new Error("oy"));
+  tryWith(true, "data", "stuff");
+  tryWith(true, "end");
+  tryWith(true, "close");
+  tryWith(true, "error", new Error("oy"));
+
+  function tryWith(doError, name, arg) {
+    var source = new events.EventEmitter();
+    var dropper = new Dropper(source, 10);
+    var coll = new EventCollector();
+
+    coll.listenAllCommon(dropper);
+
+    if (doError) {
+      source.emit("error", theError);
+    } else {
+      source.emit("end");
+    }
+
+    assert.equal(coll.events.length, 2);
+
+    if (doError) {
+      coll.assertEvent(0, dropper, "error", [theError]);
+    } else {
+      coll.assertEvent(0, dropper, "end");
+    }
+
+    coll.assertEvent(1, dropper, "close");
+    coll.reset();
+
+    // In case the event to be sent is an `error`, this listener
+    // suppresses the Node default "unhandled error" behavior.
+    source.on("error", function () { /*ignore*/ });
+
+    emit(source, name, arg);
+    assert.equal(coll.events.length, 0);
+  }
+}
+
+/**
+ * Tests basic non-multiple event sequence, using various block sizes.
+ */
+function nonMultipleEventSequence() {
+  var rawData = new Buffer(50000);
+  rawData[0] = 0;
+  rawData[1] = 1;
+  for (var i = 2; i < rawData.length; i++) {
+    rawData[i] = (i + rawData[i - 2] + rawData[i - 1]) & 0xff;
+  }
+
+  for (var i = 1; i < 500; i += 27) {
+    tryWith(i);
+  }
+
+  function tryWith(blockSize) {
+    var source = new events.EventEmitter();
+    var dropper = new Dropper(source, blockSize);
+    var coll = new EventCollector();
+
+    var data = rawData;
+    var pending = undefined; // expected pending data
+    var nextLength = 1;
+
+    coll.listenAllCommon(dropper);
+
+    while (data.length !== 0) {
+      if (nextLength > data.length) {
+        nextLength = data.length;
+      }
+
+      var emitData = data.slice(0, nextLength);
+      data = data.slice(nextLength);
+      pending = addBufs(pending, emitData);
+
+      var expectedEventCount = Math.floor(pending.length / blockSize);
+      source.emit("data", emitData);
+
+      assert.equal(coll.events.length, expectedEventCount);
+      for (var i = 0; i < expectedEventCount; i++) {
+        var expectData = pending.slice(0, blockSize);
+        pending = pending.slice(blockSize);
+        coll.assertEvent(i, dropper, "data", [expectData]);
+      }
+
+      coll.reset();
+    }
+
+    source.emit("end");
+
+    if (pending.length === 0) {
+      assert.equal(coll.events.length, 2);
+      coll.assertEvent(0, dropper, "end");
+      coll.assertEvent(1, dropper, "close");
+    } else {
+      assert.equal(coll.events.length, 3);
+      coll.assertEvent(0, dropper, "data", [pending]);
+      coll.assertEvent(1, dropper, "error",
+                       [new Error("Partial buffer at end.")]);
+      coll.assertEvent(2, dropper, "close");
+    }
+  }
+}
+
+/**
+ * Tests basic multiple-okay event sequence, using various block sizes.
+ */
+function multipleOkayEventSequence() {
+  var rawData = new Buffer(50000);
+  rawData[0] = 10;
+  rawData[1] = 12;
+  for (var i = 2; i < rawData.length; i++) {
+    rawData[i] = (i + rawData[i - 2] + rawData[i - 1]) & 0xff;
+  }
+
+  for (var i = 1; i < 500; i += 27) {
+    tryWith(i);
+  }
+
+  function tryWith(blockSize) {
+    var source = new events.EventEmitter();
+    var dropper = new Dropper(source, blockSize);
+    var coll = new EventCollector();
+
+    var data = rawData;
+    var pending = undefined; // expected pending data
+    var nextLength = 1;
+
+    coll.listenAllCommon(dropper);
+
+    while (data.length !== 0) {
+      if (nextLength > data.length) {
+        nextLength = data.length;
+      }
+
+      var emitData = data.slice(0, nextLength);
+      data = data.slice(nextLength);
+      pending = addBufs(pending, emitData);
+
+      var expectEvent = (pending.length >= blockSize);
+      source.emit("data", emitData);
+
+      assert.equal(coll.events.length, expectEvent ? 1 : 0);
+      if (expectEvent) {
+        var expectLength = (pending.length - pending.length % blockSize);
+        var expectData = pending.slice(0, expectLength);
+        pending = pending.slice(expectLength);
+        coll.assertEvent(0, dropper, "data", [expectData]);
+        coll.reset();
+      }
+    }
+
+    source.emit("end");
+
+    if (pending.length === 0) {
+      assert.equal(coll.events.length, 2);
+      coll.assertEvent(0, dropper, "end");
+      coll.assertEvent(1, dropper, "close");
+    } else {
+      assert.equal(coll.events.length, 3);
+      coll.assertEvent(0, dropper, "data", [pending]);
+      coll.assertEvent(1, dropper, "error",
+                       [new Error("Partial buffer at end.")]);
+      coll.assertEvent(2, dropper, "close");
+    }
+  }
+}
+
+/**
+ * Tests the basic error event sequence.
+ */
+function errorSequence() {
+  var source = new events.EventEmitter();
+  var dropper = new Dropper(source, 25);
+  var coll = new EventCollector();
+
+  coll.listenAllCommon(dropper);
+
+  source.emit("data", "Muffins are a perfect source of nutritive value.");
+  source.emit("error", new Error("oy"));
+  assert.equal(coll.events.length, 4);
+
+  coll.assertEvent(0, dropper, "data",
+                   [new Buffer("Muffins are a perfect sou")]);
+  coll.assertEvent(1, dropper, "data",
+                   [new Buffer("rce of nutritive value.")]);
+  coll.assertEvent(2, dropper, "error",
+                   [new Error("oy")]);
+  coll.assertEvent(3, dropper, "close");
+}
+
+/**
+ * Tests a buffered (because of `pause()`) event sequence.
+ */
+function bufferedSequence() {
+  var source = new events.EventEmitter();
+  var dropper = new Dropper(source, 20);
+  var coll = new EventCollector();
+
+  coll.listenAllCommon(dropper);
+  dropper.pause();
+
+  source.emit("data", "This ");
+  source.emit("data", "is ");
+  source.emit("data", "a ");
+  source.emit("data", "test ");
+  source.emit("data", "of ");
+  source.emit("data", "the ");
+  source.emit("data", "emergency ");
+  source.emit("data", "broadcast ");
+  source.emit("data", "system.");
+  source.emit("end");
+
+  assert.ok(dropper.readable);
+  dropper.resume();
+  assert.ok(!dropper.readable);
+
+  assert.equal(coll.events.length, 5);
+  coll.assertEvent(0, dropper, "data", [new Buffer("This is a test of th")]);
+  coll.assertEvent(1, dropper, "data", [new Buffer("e emergency broadcas")]);
+  coll.assertEvent(2, dropper, "data", [new Buffer("t system.")]);
+  coll.assertEvent(3, dropper, "error", [new Error("Partial buffer at end.")]);
+  coll.assertEvent(4, dropper, "close");
+}
+
+/**
+ * Tests that `setEncoding()` operates as expected in terms of baseline
+ * functionality.
+ */
+function setEncoding() {
+  var source = new events.EventEmitter();
+  var dropper = new Dropper(source, 6);
+  var coll = new EventCollector();
+
+  coll.listenAllCommon(dropper);
+
+  tryWith(undefined);
+  tryWith("ascii");
+  tryWith("base64");
+  tryWith("hex");
+  tryWith("utf8");
+
+  function tryWith(name) {
+    var origData = new Buffer("muffintastic");
+    var expectData1 = origData.slice(0, 6);
+    var expectData2 = origData.slice(6);
+
+    if (name) {
+      expectData1 = expectData1.toString(name);
+      expectData2 = expectData2.toString(name);
+    }
+
+    dropper.setEncoding(name);
+    source.emit("data", origData);
+    assert.equal(coll.events.length, 2);
+    coll.assertEvent(0, dropper, "data", [expectData1]);
+    coll.assertEvent(1, dropper, "data", [expectData2]);
+    coll.reset();
+  }
+}
+
+/**
+ * Tests that `setIncomingEncoding()` operates as expected in terms of
+ * baseline functionality.
+ */
+function setIncomingEncoding() {
+  var source = new events.EventEmitter();
+  var dropper = new Dropper(source, 35);
+  var coll = new EventCollector();
+
+  coll.listenAllCommon(dropper);
+
+  tryWith(undefined);
+  tryWith("ascii");
+  tryWith("base64");
+  tryWith("hex");
+  tryWith("utf8");
+
+  assert.equal(coll.events.length, 1);
+  coll.assertEvent(0, dropper, "data",
+                   [new Buffer("biscuitbiscuitbiscuitbiscuitbiscuit")]);
+
+  function tryWith(name) {
+    var origData = new Buffer("biscuit");
+    var emitData;
+
+    if (name) {
+      emitData = origData.toString(name);
+    } else {
+      emitData = origData;
+    }
+
+    dropper.setIncomingEncoding(name);
+    source.emit("data", emitData);
+  }
+}
+
+
+
+
+// FIXME: Make these work.
+
+/**
+ * Ensure that no events get passed after a `destroy()` call. Also,
+ * proves that the dropper isn't even listening for events from the
+ * source anymore.
+ */
+function afterDestroy() {
+  var source = new events.EventEmitter();
+  var dropper = new Dropper(source, 100);
+  var coll = new EventCollector();
+
+  coll.listenAllCommon(dropper);
+  dropper.destroy();
+  source.emit("data", "yes?");
+  source.emit("end");
+  source.emit("close");
+
+  assert.equal(coll.events.length, 0);
+
+  assert.equal(source.listeners("close").length, 0);
+  assert.equal(source.listeners("data").length, 0);
+  assert.equal(source.listeners("end").length, 0);
+  assert.equal(source.listeners("error").length, 0);
+}
+
+/**
+ * Ensure that things don't go haywire if a valve is destroyed in the
+ * middle of being resumed.
+ */
+function destroyDuringResume() {
+  var theData = new Buffer("stuff");
+  var source = new events.EventEmitter();
+  var valve = new Valve(source, true);
+  var coll = new EventCollector();
+
+  coll.listenAllCommon(valve);
+  source.emit("data", theData);
+  source.emit("end");
+
+  valve.on("data", function() { valve.destroy(); });
+  valve.resume();
+
+  assert.equal(coll.events.length, 1);
+  coll.assertEvent(0, valve, "data", [theData]);
+}
+
+
+function test() {
+  constructor();
+  constructorFailure();
+  readableTransition();
+  eventsAfterClose();
+  nonMultipleEventSequence();
+  multipleOkayEventSequence();
+  errorSequence();
+  bufferedSequence();
+  setEncoding();
+  setIncomingEncoding();
+
+  /* FIXME
+  afterDestroy();
+  destroyDuringResume();
+  */
+}
+
+module.exports = {
+  test: test
+};

--- a/test/eventcoll.js
+++ b/test/eventcoll.js
@@ -11,6 +11,7 @@
 "use strict";
 
 var assert = require("assert");
+var typ = require("typ");
 
 
 /*
@@ -67,9 +68,12 @@ function assertEvent(index, target, name, args) {
     if (one === other) {
       continue;
     }
-    if (Buffer.isBuffer(one)) {
-      assert.ok(Buffer.isBuffer(other));
+    if (typ.isBuffer(one)) {
+      typ.assertBuffer(other);
       assert.strictEqual(one.toString("hex"), other.toString("hex"));
+    } else if (typ.isError(one)) {
+      typ.assertError(other);
+      assert.equal(one.message, other.message);
     } else {
       assert.strictEqual(one, other);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@
 
 require("./blip").test();
 require("./cat").test();
+require("./dropper").test();
 require("./pipe").test();
 require("./sink").test();
 require("./slicer").test();


### PR DESCRIPTION
Hello danfuzz, 

Please review the following commits I made in branch 'danfuzz-encoding'.

45fdafee779dadbeabc4a1500d077b331fade269 (69 minutes ago)
Tweak.

509849d2fe0974961d62783bca0348664941ecae (71 minutes ago)
Tweak.

e093a87d2ae3bf58e4a091e48553855e89f9f471 (72 minutes ago)
Add a little flavor.

8ce0393eebacde5128e6c94781945853c18f5617 (2 hours ago)
Update docs.
Fix indentation problem, and add naming credit.

f21b8062db30d1d40a91260019f6d5062124582e (6 hours ago)
Expand and rework Dropper.
- Make construction take an `options` argument.
- Add an `ifPartial` option.

2435ee8c845095b5379e04ecc11c99651c201ae0 (18 hours ago)
Document.

5b97ec788559aa3e2c60ab250b7d469f5cf4dc49 (18 hours ago)
Add keyword.

9656e8d6156a9d733a8b463f3636c2e45ebd6bf4 (18 hours ago)
Bump version.

b2f3079c673e9aca0c4416862d712fdea0165833 (18 hours ago)
Fix up the last couple of tests.

86218bcb5f5c1ff4bee5ba74313ffabb653b5dff (23 hours ago)
Add tests for Dropper.
Not quite done enough, but I want to save the work.

f7a4f9439fc2718f0fefd4bd35aa44477d33cc8d (26 hours ago)
Fix decoder usage.

ddd3a6198709343e08228c34e33afb0553e30118 (26 hours ago)
Listen to the wrapped source.

b3339ffafffa4796427b0d0142f8ba0082d2e63c (26 hours ago)
Add `setIncomingEncoding()`.

ac238c176880cbbb0940872f4f8bd53aada2cb19 (26 hours ago)
Use the right object for `emit()`.

00415011585d84c55eab296a0de4f0fef38dfbcb (27 hours ago)
Fixes.
- Add missing `require()`s.
- Fix `bind()` call.

d1b0a9969393fbd1b98e3b6c19c6e46b25eb61f6 (28 hours ago)
Nicer format.

dfa7d668927c6b14c11ec777830a5ab7c4993ab6 (28 hours ago)
Slight clarification.

c9843f51e90ad8f1a9d039835d86d9e62f9c3c5a (28 hours ago)
Fix typo.

0530ce07428e7f70ff447df92fe22f2225b85bf6 (28 hours ago)
New class `Dropper`.
Not yet tested or vetted. Kudos to
https://github.com/rootslab/dropper for the name.

4a09227ea6987a9da8c4c3c66584624e587babe6 (29 hours ago)
Clean up Valve.
- Add more `freeze()`s.
- Removed redundant check.

85ca8b4e2975e3c7e32d04712272566fcf0de066 (2 days ago)
Cat encoding.
This implements both incoming and outgoing encoding support in the
`Cat` class.

3e439e8b3056db5554fa22d973705f023d0f190c (2 days ago)
Valve encoding.
This makes `setEncoding()` actually work for Valves and also adds
`setIncomingEncoding()` to allow it to do something sensible with
non-buffers coming into it.

R=danfuzz
VISIBLE_CHANGES=stuff
