### PR TITLE
Use Object.defineProperty() when overriding properties from a frozen prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+/.idea

--- a/lib/cat.js
+++ b/lib/cat.js
@@ -63,9 +63,9 @@ function State(emitter, streams) {
   // We `bind()` the event listener callback methods, so that they
   // get an appropriate `this` when they're called during event
   // emission.
-  this.onEnd = this.onEnd.bind(this);
-  this.onData = this.onData.bind(this);
-  this.onError = this.onError.bind(this);
+  Object.defineProperty(this, 'onEnd', { value: this.onEnd.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onData', { value: this.onData.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onError', { value: this.onError.bind(this), enumerable: true });
 
   if (!Array.isArray(streams)) {
     throw new Error("Invalid streams array.");

--- a/lib/dropper.js
+++ b/lib/dropper.js
@@ -76,9 +76,9 @@ function State(emitter, source, options) {
   // We `bind()` the event listener callback methods, so that they
   // get an appropriate `this` when they're called during event
   // emission.
-  this.onCloseOrEnd = this.onCloseOrEnd.bind(this);
-  this.onData = this.onData.bind(this);
-  this.onError = this.onError.bind(this);
+  Object.defineProperty(this, 'onCloseOrEnd', { value: this.onCloseOrEnd.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onData', { value: this.onData.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onError', { value: this.onError.bind(this), enumerable: true });
 
   source.on(consts.CLOSE, this.onCloseOrEnd);
   source.on(consts.DATA, this.onData);

--- a/lib/sink.js
+++ b/lib/sink.js
@@ -78,10 +78,10 @@ function State(emitter, source) {
   // We `bind()` the event listener callback methods, so that they
   // get an appropriate `this` when they're called during event
   // emission.
-  this.onClose = this.onClose.bind(this);
-  this.onData = this.onData.bind(this);
-  this.onEnd = this.onEnd.bind(this);
-  this.onError = this.onError.bind(this);
+  Object.defineProperty(this, 'onClose', { value: this.onClose.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onData', { value: this.onData.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onEnd', { value: this.onEnd.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onError', { value: this.onError.bind(this), enumerable: true });
 
   source.on(consts.CLOSE, this.onClose);
   source.on(consts.DATA, this.onData);

--- a/lib/slicer.js
+++ b/lib/slicer.js
@@ -190,10 +190,10 @@ function State(source) {
   // We `bind()` the event listener callback methods, so that they
   // get an appropriate `this` when they're called during event
   // emission.
-  this.onClose = this.onClose.bind(this);
-  this.onData = this.onData.bind(this);
-  this.onEnd = this.onEnd.bind(this);
-  this.onError = this.onError.bind(this);
+  Object.defineProperty(this, 'onClose', { value: this.onClose.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onData', { value: this.onData.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onEnd', { value: this.onEnd.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onError', { value: this.onError.bind(this), enumerable: true });
 
   source.on(consts.CLOSE, this.onClose);
   source.on(consts.DATA, this.onData);

--- a/lib/valve.js
+++ b/lib/valve.js
@@ -70,10 +70,10 @@ function State(emitter, source) {
   // We `bind()` the event listener callback methods, so that they
   // get an appropriate `this` when they're called during event
   // emission.
-  this.onClose = this.onClose.bind(this);
-  this.onData = this.onData.bind(this);
-  this.onEnd = this.onEnd.bind(this);
-  this.onError = this.onError.bind(this);
+  Object.defineProperty(this, 'onClose', { value: this.onClose.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onData', { value: this.onData.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onEnd', { value: this.onEnd.bind(this), enumerable: true });
+  Object.defineProperty(this, 'onError', { value: this.onError.bind(this), enumerable: true });
 
   source.on(consts.CLOSE, this.onClose);
   source.on(consts.DATA, this.onData);


### PR DESCRIPTION
Somewhere between NodeJS v0.8.18 and v0.10.2, the behaviour of Object.freeze() appears to have changed. If you upgrade to the latest NodeJS and run the pipette unit tests `npm test` then tests fail: 

``` bash
$ node --version
v0.10.2
$ npm test

> pipette@0.9.1 test pipette
> node test/test.js


pipette/lib/cat.js:66
  this.onEnd = this.onEnd.bind(this);
             ^
TypeError: Cannot assign to read only property 'onEnd' of #<State>
    at new State (pipette/lib/cat.js:66:14)
    at new Cat (pipette/lib/cat.js:236:26)
    at constructor (pipette/test/cat.js:44:7)
    at Object.test (pipette/test/cat.js:427:3)
    at Object.<anonymous> (pipette/test/test.js:4:18)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```

I wasn't able to find any documentation on whether `Object.freeze(<object>.prototype)` is really supposed to prevent object instances from overriding properties from the prototype (it sounds odd to me) so I've made a gist to test it at https://gist.github.com/felthy/5283131. Most browsers are behaving the same as the latest NodeJS so I'd say the behaviour is here to stay.

Because I'm not sure the reasoning behind freezing the prototypes, this pull request leaves the Object.freeze() calls alone and uses Object.defineProperty() instead of the assignment operator to override the instance properties. 

All unit tests are passing again with this change.
